### PR TITLE
Release version 0.6.0 and update to use metatests@0.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metatests-browser-runner",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3255,23 +3255,15 @@
       }
     },
     "metatests": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.6.2.tgz",
-      "integrity": "sha512-S9Esy3Qm4YOLRpuJ7Ot/sDyasObta446dkPpg1vJVyOleXVrK4zmgYFWDE4QfDoqOcvm0eia+8ejUJaDI+sDnQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.6.3.tgz",
+      "integrity": "sha512-B0vbJqM6CDoWiseKNQfQ0325OtJ3ZXRlhNZZ/AXMPO2666bciYhzlHCchN3r6XGOHTBQ25zzVjks/h4fjtoMnQ==",
       "dev": true,
       "requires": {
         "@metarhia/common": "^1.4.2",
         "commander": "^2.19.0",
         "tap-mocha-reporter": "^4.0.1",
         "yaml": "^1.0.2"
-      },
-      "dependencies": {
-        "@metarhia/common": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@metarhia/common/-/common-1.4.2.tgz",
-          "integrity": "sha512-DV6MjZJLaqsn+LdZaUEfyFjnC2TPY1PpfKgUYen7lcwdGdHOrgaOdXGKisDahUM7qGttM9IS6//E1ucGS7XefQ==",
-          "dev": true
-        }
       }
     },
     "micromatch": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metatests-browser-runner",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "author": "Vitaliy Semenchenko <semenchenkovitaliy@gmail.com>",
   "description": "Browser test runner for metatests",
   "license": "MIT",
@@ -42,7 +42,7 @@
     "eslint": "^5.16.0",
     "eslint-config-metarhia": "^7.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "metatests": "^0.6.2"
+    "metatests": "^0.6.3"
   },
   "peerDependencies": {
     "metatests": "^0.6.2"


### PR DESCRIPTION
This also changes versioning to signify compatible metatests version by
using major metatests version as a major version of
metatest-browser-runner.